### PR TITLE
Fix absolute filepath on Windows

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 3.1.1 (November 10, 2017)
+
+- Fixed absolute filepath on Windows
+
 ## 3.1.0 (October 1, 2017)
 
 - Added `cwd` option

--- a/index.js
+++ b/index.js
@@ -29,9 +29,12 @@ module.exports = function(options) {
 
         // temporary solution
         // should take in account options.base
-        filename = path
-            .join(cwd, path.resolve('/', filename))
-            .replace(/^[a-z]+:/i, ''); // cut drive from path on Windows platform
+        filename = path.join(
+            cwd,
+            path
+                .resolve('/', filename)
+                .replace(/^[a-z]+:/i, '') // cut drive from path on Windows platform
+        );
 
         opener.open(filename).then(
             function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-open-in-editor",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Express middleware to open file in editor",
   "author": "Roman Dvornov <rdvornov@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Currently the filepath on Windows is processed like this

    console.log( filename )
    /bower_components/paper-button/paper-button.html

    console.log( cwd )
    C:\cygwin64\home\bashmish\Projects\my-app

    console.log( path.resolve('/', filename) )
    C:\bower_components\paper-button\paper-button.html

    console.log( path.join(cwd, path.resolve('/', filename)).replace(/^[a-z]+:/i, '') )
    \cygwin64\home\bashmish\Projects\my-app\C:\bower_components\paper-button\paper-button.html

So the drive is cut from the absolute path, instead of the filename. I suggest to do it like this

    console.log( path.join(cwd, path.resolve('/', filename).replace(/^[a-z]+:/i, '')) )
    C:\cygwin64\home\bashmish\Projects\my-app\bower_components\paper-button\paper-button.html

So that drive is cut from the result of `path.resolve('/', filename)` leading to right absolute path in the end.

My solution is not coupled to cygwin environment, is generic and does not break mac/linux.